### PR TITLE
Chall00 personnal solution using strchr() and character comparisons.

### DIFF
--- a/chall00/kibotrel.c
+++ b/chall00/kibotrel.c
@@ -1,0 +1,26 @@
+#include <string.h>
+
+int	ft_necklace(char *s1, char *s2)
+{
+	int			i;
+	int			size;
+	int			offset;
+	char		*substr;
+
+	if (s1 == s2 || !strcmp(s1, s2))
+		return (1);
+	size = strlen(s1);
+	if (size != strlen(s2) || !(substr = strchr(s2, s1[0])))
+		return (0);
+	while (i = -1, substr)
+	{
+		offset = substr - s2;
+		while (++i < size)
+			if (s1[i] != s2[(i + offset) % size])
+				break;
+		if (i == size)
+			return (1);
+		substr = strchr(substr + 1, s1[0]);
+	}
+	return (0);
+}


### PR DESCRIPTION
Pour résoudre ce petit problème, on peut tout d'abord gagner du temps en identifiant des cas ou la réponse est claire pour éviter des calculs inutiles:

* Si les adresses ou le contenu des deux chaînes de caractères sont identique -> `1`.
* Si la taille des deux chaînes de caractères sont différentes -> `0`.

J'ai décidé de faire appel à [`strchr()`](http://manpagesfr.free.fr/man/man3/strchr.3.html) affin de résoudre ce problème. Etant donné que la recherche de solution se fait uniquement vers la droite (retour au début de la chaîne après le dernier caractère rencontré), en utilisant cette méthode les possibilités sont encore réduites : Si n'importe quel caractère (prenons le premier) de la première chaîne ne se trouve pas dans la seconde -> `0`.

S'en suit ensuite le processus de vérification des deux chaînes tant qu'on trouve une occurrence du caractère choisi dans la première au sein de la seconde. L'utilisation de `strchr()` permet de calculer un décalage à partir duquel on va commencer la lecture et la comparaison caractère à caractère de l’occurrence courante.  Une solution est trouvée lorsque l'intégralité de la première chaîne est parcourue sans trouver de différences dans la seconde (dans le sens de lecture, partant de l'index équivalent au décalage calculé tout en retournant au début de la chaîne lorsque le dernier caractère est atteint) -> `1`. Ceci implique qu'on peut arrêter les comparaisons à partir du premier caractère différent trouvé pour gagner du temps (et des calculs inutiles puisque le résultat sera de facto `0`).

Si toutefois à la fin de ce procédé, aucune solution est trouvée et les deux chaînes ne sont pas des permutations l'une de l'autre -> `0`.