### PR TITLE
rgb2hex

### DIFF
--- a/chall01/mbourand.c
+++ b/chall01/mbourand.c
@@ -3,7 +3,10 @@
 char *ft_rgb2hex(int r, int g, int b)
 {
 	char *base = "0123456789abcdef";
-	char *hex = malloc(sizeof(char) * 8);
+	
+	char *hex;
+	if (!(hex = malloc(sizeof(char) * 8)) || r < 0 || r > 255 || g < 0 || g > 255 || b < 0 || b > 255)
+		return (0);
 
 	hex[0] = '#';
 	hex[1] = base[r / 16];

--- a/chall01/mbourand.c
+++ b/chall01/mbourand.c
@@ -1,4 +1,3 @@
-#include <stdio.h>
 #include <stdlib.h>
 
 char *ft_rgb2hex(int r, int g, int b)

--- a/chall01/mbourand.c
+++ b/chall01/mbourand.c
@@ -1,0 +1,19 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+char *ft_rgb2hex(int r, int g, int b)
+{
+	char *base = "0123456789abcdef";
+	char *hex = malloc(sizeof(char) * 8);
+
+	hex[0] = '#';
+	hex[1] = base[r / 16];
+	hex[2] = base[r % 16];
+	hex[3] = base[g / 16];
+	hex[4] = base[g % 16];
+	hex[5] = base[b / 16];
+	hex[6] = base[b % 16];
+	hex[7] = 0;
+
+	return hex;
+}


### PR DESCRIPTION
Sachant que les composants r, g, et b sont >= 0 et <= 255, on sait qu'ils peuvent être définis par deux caractères en base hexadécimal. Avec 0 = 00 et 255 = ff.

Le premier des deux caractères correspond au nombre de fois que le composant a dépassé la taille de la base (16). Cette définition correspond simplement à une division. Le premier caractère est donc défini par base[composant / 16].

Le second caractère est tout ce qu'il reste au composant après la division, ce qui équivaut à base[composant % 16]. 

On répète ensuite ces opérations pour tous les composants.