### PR TITLE
dsy/chall01 naive solution

### DIFF
--- a/chall01/dsy_rgb_to_hex.c
+++ b/chall01/dsy_rgb_to_hex.c
@@ -1,0 +1,84 @@
+#include <unistd.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+/*
+** Utility functions
+*/
+static int	check_rgb(int n)
+{
+	if (n > 255 || n < 0)
+		return (0);
+	else
+		return (1);
+}
+
+static char*	leak(char *to_free)
+{
+	free(to_free);
+	return (NULL);
+}
+
+/*
+** Core
+*/
+
+static char	*invert_2_by_2(char *s)
+{
+	char	tmp;
+	int	i;
+
+	i = 1;
+	while (s[i] && s[i + 1])
+	{
+		tmp = s[i];
+		s[i] = s[i + 1];
+		s[i + 1] = tmp;
+		i += 2;
+	}
+	return (s);
+}
+
+static char*	int255_to_hex(int r, int g, int b, char *res)
+{
+	char	*base_16 = "0123456789abcdef";
+	int	i = 1;
+
+	res[0] = '#';
+	res[2] = '0';
+	res[4] = '0';
+	res[6] = '0';
+	while (r)
+	{
+		res[i++] = base_16[r % 16];
+		r /= 16;
+	}
+	i = 3;
+	while (g)
+	{
+		res[i++] = base_16[g % 16];
+		g /= 16;
+	}
+	i = 5;
+	while (b)
+	{
+		res[i++] = base_16[b % 16];
+		b /= 16;
+	}
+	return (invert_2_by_2(res));
+}
+
+/*
+** Driver function
+*/
+
+char		*ft_rgb2hex(int r, int g, int b)
+{
+	int	i;
+	char	*hex;
+	if (!check_rgb(r) || !check_rgb(g) || !check_rgb(b))
+		return (NULL);
+	if(!(hex = (char*)malloc(sizeof(char) * 8)))
+		return (leak(hex));
+	return (int255_to_hex(r, g, b, hex));
+}

--- a/chall01/dsy_rgb_to_hex.c
+++ b/chall01/dsy_rgb_to_hex.c
@@ -48,23 +48,26 @@ static char*	int255_to_hex(int r, int g, int b, char *res)
 	res[2] = '0';
 	res[4] = '0';
 	res[6] = '0';
-	while (r)
+	do
 	{
 		res[i++] = base_16[r % 16];
 		r /= 16;
 	}
+	while (r);
 	i = 3;
-	while (g)
+	do
 	{
 		res[i++] = base_16[g % 16];
 		g /= 16;
 	}
+	while (g);
 	i = 5;
-	while (b)
+	do
 	{
 		res[i++] = base_16[b % 16];
 		b /= 16;
 	}
+	while (b);
 	return (invert_2_by_2(res));
 }
 


### PR DESCRIPTION
Edit : fixed the 0 exception with do-while loops.

This is a naive solution for the chall01.

First we check the value of the integers we receive, if they aren't in the 0-255 range, the function will return NULL. We then allocate memory equal to the length of the string that will contain the hex number.

int255_to_hex is called, translating each number into his base 16 equivalent and putting it inside a *hex string that is pre-formated with a prefix and 0s.

Finally we return *hex, after inverting the output back in the correct reading order.

Memory allocated by ft_rgb2hex must be freed by the user

Code can be simplified by adding ft_strcat/ft_strjoin but i wanted to limit the number of malloc to minimize the possibility of leaks! 