### PR TITLE
[dgalanops' solution to chall01]

### DIFF
--- a/chall01/dgalanop.c
+++ b/chall01/dgalanop.c
@@ -1,0 +1,31 @@
+#include <stdlib.h>
+
+char	*ft_rgb2hex(int r, int g, int b)
+{
+	char	*hex;
+	int	len;
+	int	nb;
+	int	i;
+
+	if (r < 0 || r > 255 || g < 0 || g > 255 || b < 0 || b > 255)
+		return (NULL);
+	len = 7;
+	if (!(hex = (char*)malloc(sizeof(char) * len + 1)))
+		return (NULL);
+	hex[len] = '\0';
+	len--;
+	nb = b;
+	while (len > 0)
+	{
+		i = -1;
+		while (++i < 2 && len > 0)
+		{
+			hex[len] = "0123456789abcdef"[nb % 16];
+			nb = nb / 16;
+			len--;
+		}
+		nb = (len == 4) ? g : r;
+	}
+	hex[len] = '#';
+	return (hex);
+}


### PR DESCRIPTION
Pour convertir les `int` reçus dans la fonction `ft_rgb2hex` en `char*` sous forme hexadécimale, je crée une string `hex` à la manière d'un `itoa`, que je remplis donc du dernier caractère au premier.
Je convertis chaque `int` en base 16 à partir du reste de la division (modulo) que je situe sur un index allant de 0 à f. L’opération est répétée deux fois par `int`. Le changement d'`int` s'effectue en fonction de l'emplacement de la variable `len` sur la string `hex`.
Pour finir, j'ajoute un `#` au premier caractère de la string.