### PR TITLE
create ft_rgb2hex function

### DIFF
--- a/chall01/varnaud.c
+++ b/chall01/varnaud.c
@@ -1,0 +1,22 @@
+#include <stdlib.h>
+
+char	*ft_rgb2hex(int r, int g, int b)
+{
+	char	*hex;
+
+	r %= 256;
+	g %= 256;
+	b %= 256;
+	hex = (char*)malloc(sizeof(char) * 8);
+	if (hex == NULL)
+		return (NULL);
+	hex[0] = '#';
+	hex[1] = r / 16 > 9 ? r / 16 + 'a' - 10 : r / 16 + '0';
+	hex[2] = r % 16 > 9 ? r % 16 + 'a' - 10 : r % 16 + '0';
+	hex[3] = g / 16 > 9 ? g / 16 + 'a' - 10 : g / 16 + '0';
+	hex[4] = g % 16 > 9 ? g % 16 + 'a' - 10 : g % 16 + '0';
+	hex[5] = b / 16 > 9 ? b / 16 + 'a' - 10 : b / 16 + '0';
+	hex[6] = b % 16 > 9 ? b % 16 + 'a' - 10 : b % 16 + '0';
+	hex[7] = '\0';
+	return (hex);
+}


### PR DESCRIPTION
Accept 3 integers (red, green and blue) and return it's hexadecimal representation as a string (with a '#' prefix).
The code fist make sure the integers are under 256.
Then we use malloc for the hex representation.
Each integers are converted to hex and stored at the right place in the string.
e.g.
42 / 16 = 2 --> first hex
42 % 16 = 10 --> second hex
The we convert the hex to ascii.
We add 'a' - 10 if over 9.
We add '0' if under 10.